### PR TITLE
🔧 Fix Pinned Tabs in Other Windows Being Deleted on Load

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -141,7 +141,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     if (clickEvents.OPEN_GROUP_TABS_BY_GROUP_ID_ON_ELEMENT === clickEvent) {
       const groupId = target.dataset.groupId
-      const oldPinnedTabs = await browser.tabs.query({ pinned: true })
+      const oldPinnedTabs = await browser.tabs.query({ pinned: true, currentWindow: true })
       const oldPinnedTabsIds = oldPinnedTabs.map((tab) => tab.id)
 
       const newGroup = await groupRepository.findById(groupId)


### PR DESCRIPTION
## 👀 Purpose

- In relation to #9 
- To enable users to use the extension across multiple windows

## ♻️ What's changed

- Added `currentWindow: true` filter when searching for pinned tabs to remove

## 📝 Notes

- Originally raised by a user