### PR TITLE
🔧 Fixed Pinned Tabs Being Saved From Other Windows

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -213,7 +213,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     if (clickEvents.CREATE_NEW_GROUP_FROM_CURRENT_PINNED_TABS === clickEvent) {
       const groupName = document.getElementById("groupName").value
-      const pinnedTabs = await browser.tabs.query({ pinned: true })
+      const pinnedTabs = await browser.tabs.query({ pinned: true, currentWindow: true })
       const pinnedTabsUrls = pinnedTabs.map((tab) => tab.url)
 
       groupRepository.add(new GroupModel(groupName, pinnedTabsUrls)).then(() => displayStoredGroups())


### PR DESCRIPTION
## 👀 Purpose

- In relation to #10
- To ensure an intuitive process of only saving the pinned tabs for the current window

## ♻️ What's changed

- Added `currentWindow: true` filter when searching for pinned tabs to save

## 📝 Notes

- NA