### PR TITLE
✨ Add Edit Features to Saved Groups (💅 plus favicons)

### DIFF
--- a/src/handlers/clickEventHandler.js
+++ b/src/handlers/clickEventHandler.js
@@ -84,7 +84,6 @@ export class ClickEventHandler {
 
     if (this.clickEvents.REMOVE_URL_FROM_GROUP_BY_INDEX === clickEvent) {
       const index = target.dataset.index
-      console.debug(`🐛 index ${index}`)
       const { group, isLoadOnStartup } = this.editGroupView.getValues()
       group.pinnedTabsUrls.splice(index, 1)
       const groupWithRemovedUrl = new GroupEntity(group.id, group.name, group.pinnedTabsUrls)

--- a/src/handlers/clickEventHandler.js
+++ b/src/handlers/clickEventHandler.js
@@ -74,5 +74,21 @@ export class ClickEventHandler {
     if (this.clickEvents.CLOSE_EDIT_VIEW === clickEvent) {
       this.editGroupView.close()
     }
+
+    if (this.clickEvents.ADD_URL_TO_GROUP === clickEvent) {
+      const { group, isLoadOnStartup } = this.editGroupView.getValues()
+      group.pinnedTabsUrls.push([])
+      const groupWithAddedUrl = new GroupEntity(group.id, group.name, group.pinnedTabsUrls)
+      this.editGroupView.open(groupWithAddedUrl, new PreferencesModel(isLoadOnStartup))
+    }
+
+    if (this.clickEvents.REMOVE_URL_FROM_GROUP_BY_INDEX === clickEvent) {
+      const index = target.dataset.index
+      console.debug(`🐛 index ${index}`)
+      const { group, isLoadOnStartup } = this.editGroupView.getValues()
+      group.pinnedTabsUrls.splice(index, 1)
+      const groupWithRemovedUrl = new GroupEntity(group.id, group.name, group.pinnedTabsUrls)
+      this.editGroupView.open(groupWithRemovedUrl, new PreferencesModel(isLoadOnStartup))
+    }
   }
 }

--- a/src/popup.css
+++ b/src/popup.css
@@ -163,8 +163,6 @@ button:focus {
 
 .edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .edit-url {
     position: relative;
-    margin-top: 5px;
-    margin-bottom: 5px;
     flex-grow: 1; /* Makes the input take the remaining space */
 }
 .edit-overlay .content-wrapper .remove-button-wrapper {

--- a/src/popup.css
+++ b/src/popup.css
@@ -144,10 +144,28 @@ button:focus {
     border-bottom: 2px solid var(--color-primary-300);
     margin-bottom: 15px;
 }
-.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url {
-    position: relative;
-    margin: 5px 0px;
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper {
+    display: flex;
+    align-items: center; /* Centers the image vertically */
     border-left: 2px solid var(--color-primary-300);
+    margin-left: 1px;
+    margin-bottom: 5px;
+}
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper:hover {
+  cursor: pointer;
+}
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .favicon {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0; /* Prevents the image from shrinking */
+    padding: 0px 3px;
+}
+
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .edit-url {
+    position: relative;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    flex-grow: 1; /* Makes the input take the remaining space */
 }
 .edit-overlay .content-wrapper .remove-button-wrapper {
     width: 100%;

--- a/src/popup.css
+++ b/src/popup.css
@@ -160,11 +160,55 @@ button:focus {
     flex-shrink: 0; /* Prevents the image from shrinking */
     padding: 0px 3px;
 }
-
 .edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .edit-url {
     position: relative;
     flex-grow: 1; /* Makes the input take the remaining space */
 }
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .remove {
+    font-weight: bold;
+    border-radius: 2px;
+    text-align: center;
+    padding: 9px 20px;
+    font-size: 1.5em;
+    background-color: none;
+    color: var(--color-surface-500);
+}
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .remove:hover {
+    cursor: pointer;
+    filter: brightness(120%);
+    color: #d64520;
+}
+.edit-overlay .content-wrapper #editGroupsUrlsList .edit-url-wrapper .remove:focus {
+    cursor: pointer;
+    filter: brightness(120%);
+    color: #d64520;
+}
+
+.edit-overlay .content-wrapper .add-pinned-tab-wrapper {
+  display: flex;
+  justify-content: center;
+}
+.edit-overlay .content-wrapper .add-pinned-tab-wrapper .add-pinned-tab {
+  margin-top: 10px;
+  font-weight: bold;
+  padding: 10px 20px;
+  background-color: #4CAF50;
+  font-size: 1.3em;
+  border-radius: 2px;
+}
+.edit-overlay .content-wrapper .add-pinned-tab-wrapper .add-pinned-tab:hover {
+  margin-top: 8px;
+  padding: 11px 22px;
+  cursor: pointer;
+  filter: brightness(110%);
+}
+.edit-overlay .content-wrapper .add-pinned-tab-wrapper .add-pinned-tab:focus {
+  margin-top: 8px;
+  padding: 11px 22px;
+  cursor: pointer;
+  filter: brightness(110%);
+}
+
 .edit-overlay .content-wrapper .remove-button-wrapper {
     width: 100%;
     display: flex;

--- a/src/popup.html
+++ b/src/popup.html
@@ -23,8 +23,11 @@
           <h2 class="title">Pinned Tabs</h2>
           <div id="editGroupsUrlsList"></div>
         </div>
+        <div class="add-pinned-tab-wrapper">
+          <span role="button" class="add-pinned-tab" data-click-on-enter-press="true" data-click-event="ADD_URL_TO_GROUP" tabindex="0">Add Pinned Tab</span>
+        </div>
         <div class="remove-button-wrapper">
-          <span role="button" id="removeEditWrapperButton" class="remove-button" data-click-on-enter-press="true" data-click-event="REMOVE_GROUP_BY_GROUP_ID_ON_ELEMENT">Remove</span>
+          <span role="button" id="removeEditWrapperButton" class="remove-button" data-click-on-enter-press="true" data-click-event="REMOVE_GROUP_BY_GROUP_ID_ON_ELEMENT">Remove Group (cannot be undone)</span>
         </div>
       </div>
       <div class="footer">

--- a/src/popup.js
+++ b/src/popup.js
@@ -16,6 +16,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     OPEN_EDIT_VIEW_BY_GROUP_ID_ON_ELEMENT: "OPEN_EDIT_VIEW_BY_GROUP_ID_ON_ELEMENT",
     CLOSE_EDIT_VIEW: "CLOSE_EDIT_VIEW",
     CREATE_NEW_GROUP_FROM_CURRENT_PINNED_TABS: "CREATE_NEW_GROUP_FROM_CURRENT_PINNED_TABS",
+    ADD_URL_TO_GROUP: "ADD_URL_TO_GROUP",
+    REMOVE_URL_FROM_GROUP_BY_INDEX: "REMOVE_URL_FROM_GROUP_BY_INDEX",
   }
 
   const browser = chrome
@@ -26,7 +28,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const tabsClient = new TabsClient(browser)
   const tabsService = new TabsService(tabsClient)
   const groupsView = new GroupView(groupService, clickEvents)
-  const editGroupView = new EditGroupView()
+  const editGroupView = new EditGroupView(clickEvents)
   const clickEventHandler = new ClickEventHandler(groupService, preferencesService, tabsService, groupsView, editGroupView, browser, clickEvents)
 
   await groupService.removeUnlinkedGroups()

--- a/src/views/editGroupView.js
+++ b/src/views/editGroupView.js
@@ -2,8 +2,8 @@ import { GroupEntity } from "../repositories/groupRepository.js"
 import { PreferencesModel } from "../repositories/preferencesRepository.js"
 
 export class EditGroupView {
-  constructor() {
-    this.editGroupUrlsListView = new EditGroupUrlsListView()
+  constructor(clickEvents) {
+    this.editGroupUrlsListView = new EditGroupUrlsListView(clickEvents)
   }
 
   /** @param {GroupEntity>} group @param {PreferencesModel} preferences  */
@@ -52,8 +52,9 @@ export class EditGroupView {
 }
 
 export class EditGroupUrlsListView {
-  constructor() {
+  constructor(clickEvents) {
     this.id = "editGroupsUrlsList"
+    this.clickEvents = clickEvents
   }
 
   /** @param {Array<string>} urls  */
@@ -95,6 +96,14 @@ export class EditGroupUrlsListView {
     urlElement.classList.add("edit-url")
     urlElement.value = url
 
+    const removeButtonElement = document.createElement("span")
+    removeButtonElement.dataset.index = index
+    removeButtonElement.dataset.clickEvent = this.clickEvents.REMOVE_URL_FROM_GROUP_BY_INDEX
+    removeButtonElement.dataset.clickOnEnterPress = "true"
+    removeButtonElement.tabIndex = 1
+    removeButtonElement.classList.add("remove")
+    removeButtonElement.appendChild(document.createTextNode("Remove"))
+
     const urlWrapperElement = document.createElement("div")
     urlWrapperElement.dataset.index = index
     urlWrapperElement.classList.add("edit-url-wrapper")
@@ -105,6 +114,7 @@ export class EditGroupUrlsListView {
 
     urlWrapperElement.appendChild(faviconImageElement)
     urlWrapperElement.appendChild(urlElement)
+    urlWrapperElement.appendChild(removeButtonElement)
 
     editGroupsUrlsListElement.appendChild(urlWrapperElement)
   }

--- a/src/views/editGroupView.js
+++ b/src/views/editGroupView.js
@@ -42,8 +42,7 @@ export class EditGroupView {
     const groupId = document.getElementById("edit-overlay").dataset.groupId
     const newName = document.getElementById("edit-group-name").value
     const isLoadOnStartup = document.getElementById("loadOnStartupCheckbox").checked
-    const newPinnedTabsUrls = []
-    document.getElementById("editGroupsUrlsList").childNodes.forEach((child) => newPinnedTabsUrls.push(child.value))
+    const newPinnedTabsUrls = this.editGroupUrlsListView.getValues()
 
     return {
       group: new GroupEntity(groupId, newName, newPinnedTabsUrls),
@@ -80,27 +79,44 @@ export class EditGroupUrlsListView {
 
   /** @param {HTMLElement} editGroupsUrlsListElement @param {string} url  @param {number} index **/
   appendUrlInputTextBox(editGroupsUrlsListElement, url, index) {
+    const faviconImageElement = document.createElement("img")
+    faviconImageElement.dataset.index = index
+    faviconImageElement.classList.add("favicon")
+    faviconImageElement.draggable = false
+    try {
+      const domain = new URL(url).host
+      faviconImageElement.src = `https://icons.duckduckgo.com/ip3/${domain}.ico`
+    } catch (e) {
+      faviconImageElement.src = "../assets/icons/favicon-16x16.png"
+    }
+
     const urlElement = document.createElement("input")
+    urlElement.dataset.index = index
     urlElement.classList.add("edit-url")
     urlElement.value = url
-    urlElement.dataset.index = index
-    urlElement.draggable = true
-    urlElement.addEventListener("dragstart", this.dragStartHandler)
-    urlElement.ondrop = this.dropHandler
-    urlElement.ondragover = this.dragoverHandler
 
-    editGroupsUrlsListElement.appendChild(urlElement)
+    const urlWrapperElement = document.createElement("div")
+    urlWrapperElement.dataset.index = index
+    urlWrapperElement.classList.add("edit-url-wrapper")
+    urlWrapperElement.draggable = true
+    urlWrapperElement.addEventListener("dragstart", this.dragStartHandler)
+    urlWrapperElement.ondrop = this.dropHandler
+    urlWrapperElement.ondragover = this.dragoverHandler
+
+    urlWrapperElement.appendChild(faviconImageElement)
+    urlWrapperElement.appendChild(urlElement)
+
+    editGroupsUrlsListElement.appendChild(urlWrapperElement)
   }
 
   /** @returns {Array<string>} **/
   getValues() {
     const newPinnedTabsUrls = []
-    document.getElementById(this.id).childNodes.forEach((child) => newPinnedTabsUrls.push(child.value))
+    document.getElementById(this.id).childNodes.forEach((child) => newPinnedTabsUrls.push(child.querySelector("input").value))
     return newPinnedTabsUrls
   }
 
   dragStartHandler = (event) => {
-    console.debug(`🐛 dragStartHandler() - index ${event.target.dataset.index}`)
     event.dataTransfer.setData('text', event.target.dataset.index);
     event.dataTransfer.dropEffect = "move"
   }
@@ -116,7 +132,7 @@ export class EditGroupUrlsListView {
     const targetItemIndex = event.target.dataset.index
     const urls = this.getValues()
     const movingItemUrl = urls[movingItemIndex]
-    const filteredUrls = urls.filter((_, index) => Number(movingItemIndex) !== index)
+    const filteredUrls = urls.filter((_, index) => Number(movingItemIndex) !== Number(index))
     const newUrlOrder = filteredUrls.toSpliced(targetItemIndex, 0, movingItemUrl)
     this.replace(newUrlOrder)
   }

--- a/src/views/editGroupView.js
+++ b/src/views/editGroupView.js
@@ -2,7 +2,9 @@ import { GroupEntity } from "../repositories/groupRepository.js"
 import { PreferencesModel } from "../repositories/preferencesRepository.js"
 
 export class EditGroupView {
-  contructor() { }
+  constructor() {
+    this.editGroupUrlsListView = new EditGroupUrlsListView()
+  }
 
   /** @param {GroupEntity>} group @param {PreferencesModel} preferences  */
   open(group, preferences) {
@@ -24,17 +26,7 @@ export class EditGroupView {
     const editGroupNameElement = document.getElementById("edit-group-name")
     editGroupNameElement.value = group?.name
 
-    const editGroupsUrlsList = document.getElementById("editGroupsUrlsList")
-    while (editGroupsUrlsList.firstChild) {
-      editGroupsUrlsList.removeChild(editGroupsUrlsList.lastChild)
-    }
-    group?.pinnedTabsUrls?.forEach((url) => {
-      const urlElement = document.createElement("input")
-      urlElement.classList.add("edit-url")
-      urlElement.value = url
-
-      editGroupsUrlsList.appendChild(urlElement)
-    })
+    this.editGroupUrlsListView.replace(group.pinnedTabsUrls)
   }
 
   close() {
@@ -57,5 +49,75 @@ export class EditGroupView {
       group: new GroupEntity(groupId, newName, newPinnedTabsUrls),
       isLoadOnStartup: isLoadOnStartup,
     }
+  }
+}
+
+export class EditGroupUrlsListView {
+  constructor() {
+    this.id = "editGroupsUrlsList"
+  }
+
+  /** @param {Array<string>} urls  */
+  replace(urls) {
+    this.close()
+    this.open(urls)
+  }
+
+  /** @param {Array<string>} urls  */
+  open(urls) {
+    const editGroupsUrlsList = document.getElementById(this.id)
+    urls.forEach((url, index) => {
+      this.appendUrlInputTextBox(editGroupsUrlsList, url, index)
+    })
+  }
+
+  close() {
+    const editGroupsUrlsList = document.getElementById(this.id)
+    while (editGroupsUrlsList.firstChild) {
+      editGroupsUrlsList.removeChild(editGroupsUrlsList.lastChild)
+    }
+  }
+
+  /** @param {HTMLElement} editGroupsUrlsListElement @param {string} url  @param {number} index **/
+  appendUrlInputTextBox(editGroupsUrlsListElement, url, index) {
+    const urlElement = document.createElement("input")
+    urlElement.classList.add("edit-url")
+    urlElement.value = url
+    urlElement.dataset.index = index
+    urlElement.draggable = true
+    urlElement.addEventListener("dragstart", this.dragStartHandler)
+    urlElement.ondrop = this.dropHandler
+    urlElement.ondragover = this.dragoverHandler
+
+    editGroupsUrlsListElement.appendChild(urlElement)
+  }
+
+  /** @returns {Array<string>} **/
+  getValues() {
+    const newPinnedTabsUrls = []
+    document.getElementById(this.id).childNodes.forEach((child) => newPinnedTabsUrls.push(child.value))
+    return newPinnedTabsUrls
+  }
+
+  dragStartHandler = (event) => {
+    console.debug(`🐛 dragStartHandler() - index ${event.target.dataset.index}`)
+    event.dataTransfer.setData('text', event.target.dataset.index);
+    event.dataTransfer.dropEffect = "move"
+  }
+
+  dragoverHandler = (event) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+  }
+
+  dropHandler = async (event) => {
+    event.preventDefault()
+    const movingItemIndex = event.dataTransfer.getData("text")
+    const targetItemIndex = event.target.dataset.index
+    const urls = this.getValues()
+    const movingItemUrl = urls[movingItemIndex]
+    const filteredUrls = urls.filter((_, index) => Number(movingItemIndex) !== index)
+    const newUrlOrder = filteredUrls.toSpliced(targetItemIndex, 0, movingItemUrl)
+    this.replace(newUrlOrder)
   }
 }


### PR DESCRIPTION
## 👀 Purpose

- To enable users to easily edit existing groups, saving users from needing to recreate an entire group for changes such as re-ordering, adding and/or removing pinned tabs

## ♻️ What's changed

- ✨ Added favicons next to Pinned Tab URLs to make looking for a specific URL easier
- ✨ Added Drag & Drop functionality to Edit Group View - allowing users to re-order their Pinned Tabs easily
- ✨ Added Add/Remove functionality to Edit Group View
- 🆙 Updated text on the Remove Group button, to clarify it deletes the entire group and that this action cannot be undone
- ♻️ Refactored `EditGroupView` to be composed of `EditGroupUrlsListView` since this portion of the view contains a lot of functionality and interaction now

## 📝 Notes

- This wasn't a user-requested feature, but something I've been wanting myself for a few months now 🥳
- I opted to use the DuckDuckGo API for favicons, it seemed to have a better suite of favicons and returned a placeholder image less often than other options - also the placeholder image is fairly nice 🐣
- What the page now looks like 👇 
<img width="549" alt="image" src="https://github.com/user-attachments/assets/bfb02e7b-1cc5-4731-8f11-352639ab3fdd">

