### PR TITLE
🔧 Fix Icon Links

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,10 +14,10 @@
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
-      "16": "./assets/icons/favicon-16x16.png",
-      "32": "./assets/icons/favicon-32x32.png",
-      "48": "./assets/icons/favicon-48.png",
-      "128": "./assets/icons/favicon-128.png"
+      "16": "assets/icons/favicon-16x16.png",
+      "32": "assets/icons/favicon-32x32.png",
+      "48": "assets/icons/favicon-48.png",
+      "128": "assets/icons/favicon-128.png"
     }
   },
   "commands": {
@@ -29,9 +29,9 @@
     }
   },
   "icons": {
-    "16": "./assets/icons/favicon-16x16.png",
-    "32": "./assets/icons/favicon-32x32.png",
-    "48": "./assets/icons/favicon-48.png",
-    "128": "./assets/icons/favicon-128.png"
+    "16": "assets/icons/favicon-16x16.png",
+    "32": "assets/icons/favicon-32x32.png",
+    "48": "assets/icons/favicon-48.png",
+    "128": "assets/icons/favicon-128.png"
   }
 }


### PR DESCRIPTION
## 👀 Purpose

- Fixes Chrome Webstore complaining that the icons don't exist

## ♻️ What's changed

- Removed the `./` from the icon links in the manifest file