### PR TITLE
🔧 Fix `Add Pinned Tab` Not Working

### DIFF
--- a/src/handlers/clickEventHandler.js
+++ b/src/handlers/clickEventHandler.js
@@ -75,7 +75,7 @@ export class ClickEventHandler {
 
     if (this.clickEvents.ADD_URL_TO_GROUP === clickEvent) {
       const { group, isLoadOnStartup } = this.editGroupView.getValues()
-      group.pinnedTabsUrls.push([])
+      group.pinnedTabsUrls.push('')
       const groupWithAddedUrl = new GroupEntity(group.id, group.name, group.pinnedTabsUrls)
       await this.editGroupView.open(groupWithAddedUrl, new PreferencesModel(isLoadOnStartup))
     }

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -87,7 +87,7 @@ export class GroupService {
     return dynamicPinnedTabsUrls
   }
 
-  /** @returns {Promise<Array<string>>} **/
+  /** @param {string} url @returns {boolean} **/
   urlIsGroupComponent(url) {
     return url.startsWith(this.groupComponentPrefix)
   }

--- a/src/views/editGroupView.js
+++ b/src/views/editGroupView.js
@@ -143,7 +143,7 @@ export class EditGroupUrlsListView {
 
     urlElement.dataset.index = index
     urlElement.classList.add("edit-url")
-    urlElement.value = url
+    urlElement.value = url || ''
 
     return urlElement
   }
@@ -151,7 +151,7 @@ export class EditGroupUrlsListView {
   /** @returns {Array<string>} **/
   getValues() {
     const newPinnedTabsUrls = []
-    document.getElementById(this.id).childNodes.forEach((child) => newPinnedTabsUrls.push(child.querySelector("input")?.value || child.querySelector("select :checked")?.value))
+    document.getElementById(this.id).childNodes.forEach((child) => newPinnedTabsUrls.push(child.querySelector("input")?.value || child.querySelector("select :checked")?.value || ''))
     return newPinnedTabsUrls
   }
 


### PR DESCRIPTION
## 👀 Purpose

- Identified that the `Add Pinned Tab` button had stopped working after recent changes, this PR fixes that

## ♻️ What's changed

- Corrected `group.pinnedTabsUrls.push([])` to `group.pinnedTabsUrls.push('')` as the value needs to be a string, not an array (got away with this before as the value wasn't really used)
- Set default values of `''` where we are displaying, fetching or creating a new pinned tab in a group
- Updated some JSDocs
